### PR TITLE
chore: remove pending TODO and make output the same as the python version

### DIFF
--- a/patches.patch
+++ b/patches.patch
@@ -1,6 +1,6 @@
 diff -ruwN orig/decidim/electionguard/common.py build/decidim/electionguard/common.py
---- orig/decidim/electionguard/common.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/decidim/electionguard/common.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/decidim/electionguard/common.py	2020-11-03 10:10:47.000000000 +0100
++++ build/decidim/electionguard/common.py	2020-10-28 15:25:36.000000000 +0100
 @@ -12,7 +12,7 @@
      #quorum: int
  
@@ -11,18 +11,19 @@ diff -ruwN orig/decidim/electionguard/common.py build/decidim/electionguard/comm
          if not self.election.is_valid():
              raise InvalidElectionDescription()
 diff -ruwN orig/decidim/electionguard/utils.py build/decidim/electionguard/utils.py
---- orig/decidim/electionguard/utils.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/decidim/electionguard/utils.py	2020-10-28 10:01:57.000000000 +0100
-@@ -1,45 +1,8 @@
+--- orig/decidim/electionguard/utils.py	2020-11-03 10:10:47.000000000 +0100
++++ build/decidim/electionguard/utils.py	2020-11-03 10:28:42.000000000 +0100
+@@ -1,46 +1,7 @@
 -from base64 import b64encode, b64decode
  from electionguard.group import ElementModP, ElementModQ
  import electionguard.serializable
+-from gmpy2 import mpz
  
 -# -- TEMPORARY MONKEYPATCH JSONS SERIALIZATION --
 -old_set_serializers = electionguard.serializable.set_serializers
 -old_set_deserializers = electionguard.serializable.set_deserializers
 -electionguard.serializable.KEYS_TO_REMOVE += ['nonce']  # Remove nonces when serializing to JSON
- 
+-
 -
 -def set_serializers():
 -    old_set_serializers()
@@ -42,17 +43,17 @@ diff -ruwN orig/decidim/electionguard/utils.py build/decidim/electionguard/utils
 -
 -
 -def serialize_big_number(obj , **_):
--    number = obj.to_int()
+-    number = int(obj.to_int())
 -    return b64encode(
 -        number.to_bytes(
 -            (number.bit_length() + 7) // 8,
--            byteorder='little'
+-            byteorder='big'
 -        )
 -    ).decode('utf-8')
 -
 -
 -def deserialize_big_number(obj, cls, **_):
--    return cls(int.from_bytes(b64decode(obj), byteorder='little'))
+-    return cls(mpz(int.from_bytes(b64decode(obj), byteorder='big')))
 -
 -
 -def serialize(obj, include_private  = False):
@@ -60,7 +61,7 @@ diff -ruwN orig/decidim/electionguard/utils.py build/decidim/electionguard/utils
      return electionguard.serializable.write_json_object(obj, not include_private)
  
  
-@@ -48,7 +11,7 @@
+@@ -49,7 +10,7 @@
  
  
  def deserialize_key(obj):
@@ -69,7 +70,7 @@ diff -ruwN orig/decidim/electionguard/utils.py build/decidim/electionguard/utils
  
  
  class InvalidElectionDescription(Exception):
-@@ -66,24 +29,24 @@
+@@ -67,24 +28,28 @@
  
  
  def complete_election_description(election_description )  :
@@ -86,14 +87,18 @@ diff -ruwN orig/decidim/electionguard/utils.py build/decidim/electionguard/utils
          },
          'election_scope_id': 'test-election',
 -        'type': 'special',
-+        '_type': 'special',
++        '_type': {
++            '_name': 'special'
++        },
          'geopolitical_units': [
              {
                  'object_id': 'a-place',
 -                'name': 'A place',
 -                'type': 'county',
 +                '_name': 'A place',
-+                '_type': 'county',
++                '_type': {
++                    '_name': 'county',
++                },
                  'contact_information': {
                      'address_line': [],
 -                    'name': 'Organization name',
@@ -101,7 +106,7 @@ diff -ruwN orig/decidim/electionguard/utils.py build/decidim/electionguard/utils
                      'email': [{'annotation': 'contact', 'value': 'contact@example.org'}]
                  },
                  'phone': []
-@@ -96,7 +59,7 @@
+@@ -97,7 +62,7 @@
                  'geopolitical_unit_ids': ['a-place']
              }
          ]
@@ -111,32 +116,52 @@ diff -ruwN orig/decidim/electionguard/utils.py build/decidim/electionguard/utils
      for contest in complete_description['contests']:
          contest['electoral_district_id'] = 'a-place'
 diff -ruwN orig/decidim/electionguard/voter.py build/decidim/electionguard/voter.py
---- orig/decidim/electionguard/voter.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/decidim/electionguard/voter.py	2020-10-28 10:01:57.000000000 +0100
-@@ -50,9 +50,9 @@
+--- orig/decidim/electionguard/voter.py	2020-11-03 10:10:47.000000000 +0100
++++ build/decidim/electionguard/voter.py	2020-11-02 16:30:32.000000000 +0100
+@@ -5,7 +5,9 @@
+ from typing import List
+ from decidim.electionguard.common import Context, ElectionStep, Wrapper
+ from decidim.electionguard.utils import MissingJointKey, serialize, deserialize_key
++import BigInteger as bigInt
+ 
++mpz = bigInt
+ 
+ class VoterContext(Context):
+     has_joint_key  = False
+@@ -24,7 +26,6 @@
+ 
+     def process_message(self, message_type , message , context ):
+         joint_key = deserialize_key(message['joint_election_key'])
+-
+         context.election_builder.set_public_key(get_optional(joint_key))
+         context.election_metadata, context.election_context = get_optional(context.election_builder.build())
+         context.has_joint_key = True
+@@ -50,20 +51,12 @@
                  for selection in contest.ballot_selections
              ]
  
 -            contests.append(PlaintextBallotContest(contest.object_id, selections))
-+            contests.append(PlaintextBallotContest(ballot_id = contest.object_id, selections = selections))
++            contests.append(PlaintextBallotContest(object_id = contest.object_id, ballot_selections = selections))
  
 -        plaintext_ballot = PlaintextBallot(self.ballot_id, ballot_style, contests)
-+        plaintext_ballot = PlaintextBallot(ballot_id = self.ballot_id, ballot_style = ballot_style, contests = contests)
++        plaintext_ballot = PlaintextBallot(object_id = self.ballot_id, ballot_style = ballot_style, contests = contests)
  
          # TODO: store the audit information somewhere
  
-@@ -60,7 +60,7 @@
+-        # return serialize(encrypt_ballot(
+-        #     plaintext_ballot,
+-        #     self.context.election_metadata,
+-        #     self.context.election_context,
+-        #     ElementModQ(0),
+-        #     None,
+-        #     True
+-        # ))
+         return encrypt_ballot(
              plaintext_ballot,
              self.context.election_metadata,
-             self.context.election_context,
--            ElementModQ(0),
-+            ElementModQ(2**255 + 123), # TO-DO: use an election hash
-             None,
-             True
-         ))
 diff -ruwN orig/distutils.py build/distutils.py
 --- orig/distutils.py	1970-01-01 01:00:00.000000000 +0100
-+++ build/distutils.py	2020-10-28 10:01:57.000000000 +0100
++++ build/distutils.py	2020-10-28 15:25:36.000000000 +0100
 @@ -0,0 +1,5 @@
 +class Util:
 +    def strtobool(str):
@@ -145,8 +170,8 @@ diff -ruwN orig/distutils.py build/distutils.py
 +util = Util()
 \ No newline at end of file
 diff -ruwN orig/electionguard/ballot.py build/electionguard/ballot.py
---- orig/electionguard/ballot.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/ballot.py	2020-10-28 12:39:42.000000000 +0100
+--- orig/electionguard/ballot.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/ballot.py	2020-11-02 16:55:52.000000000 +0100
 @@ -1,8 +1,6 @@
  from dataclasses import dataclass, field, replace
  from datetime import datetime
@@ -250,16 +275,7 @@ diff -ruwN orig/electionguard/ballot.py build/electionguard/ballot.py
  
      is_placeholder_selection  = field(default=False)
      """Determines if this is a placeholder selection"""
-@@ -209,6 +224,8 @@
-         :param elgamal_public_key: The election public key
-         """
- 
-+        return True # TO-DO: arreglar generación de pruebas
-+
-         if seed_hash != self.description_hash:
-             log_warning(
-                 f"mismatching selection hash: {self.object_id} expected({str(seed_hash)}), actual({str(self.description_hash)})"
-@@ -216,7 +233,7 @@
+@@ -216,7 +231,7 @@
              return False
  
          recalculated_crypto_hash = self.crypto_hash_with(seed_hash)
@@ -268,7 +284,7 @@ diff -ruwN orig/electionguard/ballot.py build/electionguard/ballot.py
              log_warning(
                  f"mismatching crypto hash: {self.object_id} expected({str(recalculated_crypto_hash)}), actual({str(self.crypto_hash)})"
              )
-@@ -317,6 +334,10 @@
+@@ -317,6 +332,10 @@
      while complete contests are passed into ElectionGuard when running encryption on an existing dataset.
      """
  
@@ -279,7 +295,15 @@ diff -ruwN orig/electionguard/ballot.py build/electionguard/ballot.py
      ballot_selections  = field(
          default_factory=lambda: []
      )
-@@ -395,14 +416,19 @@
+@@ -349,6 +368,7 @@
+ 
+         number_elected = 0
+         votes = 0
++
+         # Verify the selections are well-formed
+         for selection in self.ballot_selections:
+             selection_count = selection.to_int()
+@@ -394,14 +414,19 @@
      then it is required in order to regenerate the proof.
      """
  
@@ -293,28 +317,36 @@ diff -ruwN orig/electionguard/ballot.py build/electionguard/ballot.py
 -    """Collection of ballot selections"""
 +        ["ballot_selections", [CiphertextBallotSelection]],
 +        #"""Collection of ballot selections"""
-+
-+        ["crypto_hash", ElementModQ],
-+        #"""Hash of the encrypted values"""
  
 -    #crypto_hash: ElementModQ
 -    """Hash of the encrypted values"""
++        ["crypto_hash", ElementModQ],
++        #"""Hash of the encrypted values"""
++
 +        ["nonce", Nonces],
 +        ["proof", Proof]
 +    ]
  
      nonce  = None
      """The nonce used to generate the encryption. Sensitive & should be treated as a secret"""
-@@ -472,6 +498,8 @@
+@@ -471,6 +496,7 @@
          Specifically, the seed hash in this context is the hash of the ContestDescription, 
          or whatever `ElementModQ` was used to populate the `description_hash` field.
          """
-+        return True # TO-DO: arreglar generación de pruebas
 +
          if seed_hash != self.description_hash:
              log_warning(
                  f"mismatching contest hash: {self.object_id} expected({str(seed_hash)}), actual({str(self.description_hash)})"
-@@ -491,6 +519,8 @@
+@@ -478,7 +504,7 @@
+             return False
+ 
+         recalculated_crypto_hash = self.crypto_hash_with(seed_hash)
+-        if self.crypto_hash != recalculated_crypto_hash:
++        if self.crypto_hash.__ne__(recalculated_crypto_hash):
+             log_warning(
+                 f"mismatching crypto hash: {self.object_id} expected({str(recalculated_crypto_hash)}), actual({str(self.crypto_hash)})"
+             )
+@@ -490,6 +516,8 @@
              log_warning(f"no proof exists for: {self.object_id}")
              return False
  
@@ -323,7 +355,7 @@ diff -ruwN orig/electionguard/ballot.py build/electionguard/ballot.py
          # Verify the sum of the selections matches the proof
          elgamal_accumulation = self.elgamal_accumulate()
          return self.proof.is_valid(
-@@ -589,11 +619,13 @@
+@@ -588,11 +616,13 @@
      :field object_id: A unique Ballot ID that is relevant to the external system
      """
  
@@ -341,7 +373,7 @@ diff -ruwN orig/electionguard/ballot.py build/electionguard/ballot.py
  
      def is_valid(self, expected_ballot_style_id )  :
          """
-@@ -633,29 +665,31 @@
+@@ -632,29 +662,31 @@
      :field object_id: A unique Ballot ID that is relevant to the external system
      """
  
@@ -389,16 +421,16 @@ diff -ruwN orig/electionguard/ballot.py build/electionguard/ballot.py
  
      def __eq__(self, other )  :
          return (
-@@ -741,6 +775,8 @@
-         or whatever `ElementModQ` was used to populate the `description_hash` field.
-         """
+@@ -747,7 +779,7 @@
+             return False
  
-+        return True # TO-DO: arreglar generación de pruebas
-+
-         if seed_hash != self.description_hash:
+         recalculated_crypto_hash = self.crypto_hash_with(seed_hash)
+-        if self.crypto_hash != recalculated_crypto_hash:
++        if self.crypto_hash.__ne__(recalculated_crypto_hash):
              log_warning(
-                 f"mismatching ballot hash: {self.object_id} expected({str(seed_hash)}), actual({str(self.description_hash)})"
-@@ -813,7 +849,7 @@
+                 f"mismatching crypto hash: {self.object_id} expected({str(recalculated_crypto_hash)}), actual({str(self.crypto_hash)})"
+             )
+@@ -812,7 +844,7 @@
      def __eq__(self, other )  :
          return (
              isinstance(other, CiphertextAcceptedBallot)
@@ -408,8 +440,8 @@ diff -ruwN orig/electionguard/ballot.py build/electionguard/ballot.py
          )
  
 diff -ruwN orig/electionguard/chaum_pedersen.py build/electionguard/chaum_pedersen.py
---- orig/electionguard/chaum_pedersen.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/chaum_pedersen.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/chaum_pedersen.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/chaum_pedersen.py	2020-11-03 09:50:06.000000000 +0100
 @@ -19,6 +19,8 @@
  from electionguard.nonces import Nonces
  from electionguard.proof import Proof, ProofUsage
@@ -447,6 +479,26 @@ diff -ruwN orig/electionguard/chaum_pedersen.py build/electionguard/chaum_peders
          a0 = self.proof_zero_pad
          b0 = self.proof_zero_data
          a1 = self.proof_one_pad
+@@ -82,13 +92,13 @@
+         in_bounds_c1 = c1.is_in_bounds()
+         in_bounds_v0 = v0.is_in_bounds()
+         in_bounds_v1 = v1.is_in_bounds()
+-        consistent_c = add_q(c0, c1) == c == hash_elems(q, alpha, beta, a0, b0, a1, b1)
+-        consistent_gv0 = g_pow_p(v0) == mult_p(a0, pow_p(alpha, c0))
+-        consistent_gv1 = g_pow_p(v1) == mult_p(a1, pow_p(alpha, c1))
+-        consistent_kv0 = pow_p(k, v0) == mult_p(b0, pow_p(beta, c0))
+-        consistent_gc1kv1 = mult_p(g_pow_p(c1), pow_p(k, v1)) == mult_p(
++        consistent_c = add_q(c0, c1).__eq__(c) and c.__eq__(hash_elems(q, alpha, beta, a0, b0, a1, b1))
++        consistent_gv0 = g_pow_p(v0).__eq__(mult_p(a0, pow_p(alpha, c0)))
++        consistent_gv1 = g_pow_p(v1).__eq__(mult_p(a1, pow_p(alpha, c1)))
++        consistent_kv0 = pow_p(k, v0).__eq__(mult_p(b0, pow_p(beta, c0)))
++        consistent_gc1kv1 = mult_p(g_pow_p(c1), pow_p(k, v1)).__eq__(mult_p(
+             b1, pow_p(beta, c1)
+-        )
++        ))
+ 
+         success = (
+             in_bounds_alpha
 @@ -153,8 +163,11 @@
      usage  = ProofUsage.SecretValue
      """a description of how to use this proof"""
@@ -470,6 +522,32 @@ diff -ruwN orig/electionguard/chaum_pedersen.py build/electionguard/chaum_peders
          a = self.pad
          b = self.data
          c = self.challenge
+@@ -193,14 +206,14 @@
+         in_bounds_v = v.is_in_bounds()
+         in_bounds_q = q.is_in_bounds()
+ 
+-        same_c = c == hash_elems(q, alpha, beta, a, b, m)
++        same_c = c.__eq__(hash_elems(q, alpha, beta, a, b, m))
+         consistent_gv = (
+             in_bounds_v
+             and in_bounds_a
+             and in_bounds_c
+             and in_bounds_v
+             # The equation 𝑔^𝑣𝑖 = 𝑎𝑖𝐾^𝑐𝑖
+-            and g_pow_p(v) == mult_p(a, pow_p(k, c))
++            and g_pow_p(v).__eq__(mult_p(a, pow_p(k, c)))
+         )
+ 
+         # The equation 𝐴^𝑣𝑖 = 𝑏𝑖𝑀𝑖^𝑐𝑖 mod 𝑝
+@@ -209,7 +222,7 @@
+             and in_bounds_b
+             and in_bounds_c
+             and in_bounds_v
+-            and pow_p(alpha, v) == mult_p(b, pow_p(m, c))
++            and pow_p(alpha, v).__eq__(mult_p(b, pow_p(m, c)))
+         )
+ 
+         success = (
 @@ -272,8 +285,12 @@
      usage  = ProofUsage.SelectionLimit
      """a description of how to use this proof"""
@@ -494,7 +572,39 @@ diff -ruwN orig/electionguard/chaum_pedersen.py build/electionguard/chaum_peders
          a = self.pad
          b = self.data
          c = self.challenge
-@@ -412,10 +429,10 @@
+@@ -311,20 +328,20 @@
+         # this is an arbitrary constant check to verify that decryption will be performant
+         # in some use cases this value may need to be increased
+         sane_constant = 0 <= constant < 1_000_000_000
+-        same_c = c == hash_elems(q, alpha, beta, a, b)
++        same_c = c.__eq__(hash_elems(q, alpha, beta, a, b))
+         consistent_gv = (
+             in_bounds_v
+             and in_bounds_a
+             and in_bounds_alpha
+             and in_bounds_c
+             # The equation 𝑔^𝑉 = 𝑎𝐴^𝐶 mod 𝑝
+-            and g_pow_p(v) == mult_p(a, pow_p(alpha, c))
++            and g_pow_p(v).__eq__(mult_p(a, pow_p(alpha, c)))
+         )
+ 
+         # The equation 𝑔^𝐿𝐾^𝑣 = 𝑏𝐵^𝐶 mod 𝑝
+         consistent_kv = in_bounds_constant and mult_p(
+             g_pow_p(mult_p(c, constant_q)), pow_p(k, v)
+-        ) == mult_p(b, pow_p(beta, c))
++        ).__eq__(mult_p(b, pow_p(beta, c)))
+ 
+         success = (
+             in_bounds_alpha
+@@ -385,7 +402,6 @@
+     :param seed: Used to generate other random values here
+     :param plaintext: Zero or one
+     """
+-
+     assert (
+         0 <= plaintext <= 1
+     ), "make_disjunctive_chaum_pedersen only supports plaintexts of 0 or 1"
+@@ -412,10 +428,10 @@
                          usually the election extended base hash (𝑄')
      :param seed: Used to generate other random values here
      """
@@ -507,7 +617,7 @@ diff -ruwN orig/electionguard/chaum_pedersen.py build/electionguard/chaum_peders
  
      # Compute the NIZKP
      a0 = g_pow_p(u0)
-@@ -447,10 +464,10 @@
+@@ -447,10 +463,10 @@
                          usually the election extended base hash (𝑄')
      :param seed: Used to generate other random values here
      """
@@ -520,7 +630,7 @@ diff -ruwN orig/electionguard/chaum_pedersen.py build/electionguard/chaum_peders
  
      # Compute the NIZKP
      q_minus_c0 = negate_q(c0)
-@@ -483,10 +500,10 @@
+@@ -483,10 +499,10 @@
      :param hash_header: A value used when generating the challenge, 
                          usually the election extended base hash (𝑄')
      """
@@ -533,7 +643,7 @@ diff -ruwN orig/electionguard/chaum_pedersen.py build/electionguard/chaum_peders
      a = g_pow_p(u)  # 𝑔^𝑢𝑖 mod 𝑝
      b = pow_p(alpha, u)  # 𝐴^𝑢𝑖 mod 𝑝
      c = hash_elems(hash_header, alpha, beta, a, b, m)  # sha256(𝑄', A, B, a𝑖, b𝑖, 𝑀𝑖)
-@@ -514,10 +531,10 @@
+@@ -514,10 +530,10 @@
      :param hash_header: A value used when generating the challenge,
                          usually the election extended base hash (𝑄')
      """
@@ -547,8 +657,8 @@ diff -ruwN orig/electionguard/chaum_pedersen.py build/electionguard/chaum_peders
      b = pow_p(k, u)  # 𝐴^𝑢𝑖 mod 𝑝
      c = hash_elems(hash_header, alpha, beta, a, b)  # sha256(𝑄', A, B, a, b)
 diff -ruwN orig/electionguard/dlog.py build/electionguard/dlog.py
---- orig/electionguard/dlog.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/dlog.py	2020-10-28 10:07:48.000000000 +0100
+--- orig/electionguard/dlog.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/dlog.py	2020-10-28 15:25:51.000000000 +0100
 @@ -1,8 +1,5 @@
  # support for computing discrete logs, with a cache so they're never recomputed
  
@@ -581,8 +691,8 @@ diff -ruwN orig/electionguard/dlog.py build/electionguard/dlog.py
          while e != __dlog_max_elem:
              __dlog_max_exp = __dlog_max_exp + 1
 diff -ruwN orig/electionguard/election.py build/electionguard/election.py
---- orig/electionguard/election.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/election.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/election.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/election.py	2020-10-30 10:15:50.000000000 +0100
 @@ -1,7 +1,6 @@
  from dataclasses import dataclass, field, InitVar
  from datetime import datetime
@@ -599,7 +709,27 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
  
  @unique
  class ElectionType(Enum):
-@@ -149,13 +149,13 @@
+@@ -129,6 +129,9 @@
+     Data entity used to represent multi-national text. Use when text on a ballot contains multi-national text.
+     See: https://developers.google.com/elections-data/reference/internationalized-text
+     """
++    _types = [
++        ["text", [Language]]
++    ]
+ 
+     text  = field(default_factory=lambda: [])
+ 
+@@ -145,17 +148,23 @@
+     For defining contact information about objects such as persons, boards of authorities, and organizations.
+     See: https://developers.google.com/elections-data/reference/contact-information
+     """
++    _types = [
++        ["address_line", [str]],
++        ["email", [AnnotatedString]],
++        ["phone", [AnnotatedString]],
++        ["_name", str]
++    ]
+ 
      address_line  = field(default=None)
      email  = field(default=None)
      phone  = field(default=None)
@@ -615,7 +745,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
  
  
  @dataclass(eq=True, unsafe_hash=True)
-@@ -166,8 +166,12 @@
+@@ -166,8 +175,12 @@
      See: https://developers.google.com/elections-data/reference/gp-unit
      """
  
@@ -630,7 +760,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
      contact_information  = field(default=None)
  
      def crypto_hash(self)  :
-@@ -175,7 +179,7 @@
+@@ -175,7 +188,7 @@
          A hash representation of the object
          """
          return hash_elems(
@@ -639,7 +769,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
          )
  
  
-@@ -185,6 +189,12 @@
+@@ -185,6 +198,12 @@
      A BallotStyle works as a key to uniquely specify a set of contests. See also `ContestDescription`.
      """
  
@@ -652,7 +782,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
      geopolitical_unit_ids  = field(default=None)
      party_ids  = field(default=None)
      image_uri  = field(default=None)
-@@ -205,6 +215,13 @@
+@@ -205,6 +224,13 @@
      See: https://developers.google.com/elections-data/reference/party
      """
  
@@ -666,7 +796,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
      ballot_name  = field(default=InternationalizedText())
      abbreviation  = field(default=None)
      color  = field(default=None)
-@@ -241,6 +258,13 @@
+@@ -241,6 +267,13 @@
      selections for the contest.  See the wiki, readme's, and tests in this repo for more info
      """
  
@@ -680,7 +810,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
      ballot_name  = field(default=InternationalizedText())
      party_id  = field(default=None)
      image_uri  = field(default=None)
-@@ -276,8 +300,11 @@
+@@ -276,8 +309,11 @@
      however that information is not captured by default when encrypting a specific ballot.
      """
  
@@ -694,7 +824,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
      """
      Used for ordering selections in a contest to ensure various encryption primitives are deterministic.
      The sequence order must be unique and should be representative of how the contests are represnted
-@@ -305,28 +332,33 @@
+@@ -305,28 +341,33 @@
      however that information is not captured by default when encrypting a specific ballot.
      """
  
@@ -727,20 +857,20 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
      # to indicate how many total votes a voter can spread around. In n-of-m elections, this will
      # be None.
 -    #votes_allowed: Optional[int]
-+        ["votes_allowed", "Optional"],
++        ["votes_allowed", "Optional"], # TODO: not the correct type
  
      # Name of the contest, not necessarily as it appears on the ballot.
 -    #name: str
 +        ["_name", str],
 +
 +        ["ballot_selections", [SelectionDescription]],
-+        ["ballot_title", str],
-+        ["ballot_subtitle", str]
++        ["ballot_title", InternationalizedText],
++        ["ballot_subtitle", InternationalizedText]
 +    ]
  
      # For associating a ballot selection for the contest, i.e., a candidate, a ballot measure.
      ballot_selections  = field(default_factory=lambda: [])
-@@ -345,7 +377,7 @@
+@@ -345,7 +386,7 @@
              and self.votes_allowed == other.votes_allowed
              and self.number_elected == other.number_elected
              and self.votes_allowed == other.votes_allowed
@@ -749,7 +879,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
              and _list_eq(self.ballot_selections, other.ballot_selections)
              and self.ballot_title == other.ballot_title
              and self.ballot_subtitle == other.ballot_subtitle
-@@ -363,10 +395,10 @@
+@@ -363,10 +404,10 @@
              self.object_id,
              self.sequence_order,
              self.electoral_district_id,
@@ -762,7 +892,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
              self.number_elected,
              self.votes_allowed,
              self.ballot_selections,
-@@ -531,23 +563,28 @@
+@@ -531,23 +572,28 @@
      See: https://developers.google.com/elections-data/reference/election
      """
  
@@ -786,7 +916,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
 +        ["candidates", [Candidate]],
 +        ["contests", [ContestDescription]],
 +        ["ballot_styles", [BallotStyle]],
-+        ["_name", str],
++        ["_name", InternationalizedText],
 +        ["contact_information", ContactInformation]
 +    ]
 +
@@ -802,7 +932,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
              and self.start_date == other.start_date
              and self.end_date == other.end_date
              and _list_eq(self.geopolitical_units, other.geopolitical_units)
-@@ -555,7 +592,7 @@
+@@ -555,7 +601,7 @@
              and _list_eq(self.candidates, other.candidates)
              and _list_eq(self.contests, other.contests)
              and _list_eq(self.ballot_styles, other.ballot_styles)
@@ -811,8 +941,11 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
              and self.contact_information == other.contact_information
          )
  
-@@ -566,10 +603,10 @@
- 
+@@ -563,13 +609,12 @@
+         """
+         Returns a hash of the metadata components of the election
+         """
+-
          return hash_elems(
              self.election_scope_id,
 -            str(self.type.name),
@@ -824,7 +957,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
              self.contact_information,
              self.geopolitical_units,
              self.parties,
-@@ -739,13 +776,12 @@
+@@ -739,13 +784,12 @@
  
      description_hash  = field(init=False)
  
@@ -844,7 +977,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
  
      def contest_for(
          self, contest_id 
-@@ -844,26 +880,25 @@
+@@ -844,26 +888,25 @@
      `make_ciphertext_election_context` instead.
      """
  
@@ -882,7 +1015,15 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
  
  
  def make_ciphertext_election_context(
-@@ -927,7 +962,7 @@
+@@ -900,6 +943,7 @@
+     crypto_base_hash = hash_elems(
+         P, Q, G, number_of_guardians, quorum, description_hash
+     )
++
+     crypto_extended_base_hash = hash_elems(crypto_base_hash, elgamal_public_key)
+     return CiphertextElectionContext(
+         number_of_guardians=number_of_guardians,
+@@ -927,7 +971,7 @@
          vote_variation=description.vote_variation,
          number_elected=description.number_elected,
          votes_allowed=description.votes_allowed,
@@ -891,7 +1032,7 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
          ballot_selections=description.ballot_selections,
          ballot_title=description.ballot_title,
          ballot_subtitle=description.ballot_subtitle,
-@@ -954,11 +989,11 @@
+@@ -954,11 +998,11 @@
          )
          return None
  
@@ -908,8 +1049,8 @@ diff -ruwN orig/electionguard/election.py build/electionguard/election.py
  
  
 diff -ruwN orig/electionguard/election_builder.py build/electionguard/election_builder.py
---- orig/electionguard/election_builder.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/election_builder.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/election_builder.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/election_builder.py	2020-10-29 12:52:03.000000000 +0100
 @@ -1,7 +1,4 @@
 -from __future__ import annotations
 -
@@ -931,8 +1072,8 @@ diff -ruwN orig/electionguard/election_builder.py build/electionguard/election_b
  
      def set_public_key(self, elgamal_public_key )  :
 diff -ruwN orig/electionguard/election_object_base.py build/electionguard/election_object_base.py
---- orig/electionguard/election_object_base.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/election_object_base.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/election_object_base.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/election_object_base.py	2020-10-28 15:25:36.000000000 +0100
 @@ -2,6 +2,7 @@
  
  from electionguard.serializable import Serializable
@@ -942,8 +1083,8 @@ diff -ruwN orig/electionguard/election_object_base.py build/electionguard/electi
  @dataclass
  class ElectionObjectBase(Serializable):
 diff -ruwN orig/electionguard/elgamal.py build/electionguard/elgamal.py
---- orig/electionguard/elgamal.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/elgamal.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/elgamal.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/elgamal.py	2020-10-28 17:52:09.000000000 +0100
 @@ -1,5 +1,3 @@
 -from typing import Iterable, NamedTuple, Optional
 -
@@ -986,8 +1127,8 @@ diff -ruwN orig/electionguard/elgamal.py build/electionguard/elgamal.py
          """
          Decrypts an ElGamal ciphertext with a "known product" (the blinding factor used in the encryption).
 diff -ruwN orig/electionguard/encrypt.py build/electionguard/encrypt.py
---- orig/electionguard/encrypt.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/encrypt.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/encrypt.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/encrypt.py	2020-11-03 10:39:58.000000000 +0100
 @@ -1,6 +1,3 @@
 -from typing import List, Optional
 -from uuid import getnode
@@ -995,9 +1136,12 @@ diff -ruwN orig/electionguard/encrypt.py build/electionguard/encrypt.py
  from electionguard.ballot import (
      CiphertextBallot,
      CiphertextBallotContest,
-@@ -25,69 +22,9 @@
+@@ -23,71 +20,11 @@
+ from electionguard.elgamal import elgamal_encrypt
+ from electionguard.group import ElementModP, ElementModQ, rand_q
  from electionguard.logs import log_warning
- from electionguard.nonces import Nonces
+-from electionguard.nonces import Nonces
++from Nonces import Nonces
  from electionguard.serializable import Serializable
 -from electionguard.tracker import get_hash_for_device
  from electionguard.utils import get_optional, get_or_else_optional_func
@@ -1084,31 +1228,43 @@ diff -ruwN orig/electionguard/encrypt.py build/electionguard/encrypt.py
  
  
  def encrypt_selection(
-@@ -159,8 +96,8 @@
+@@ -159,7 +96,7 @@
  
      selection_description_hash = selection_description.crypto_hash()
      nonce_sequence = Nonces(selection_description_hash, nonce_seed)
 -    selection_nonce = nonce_sequence[selection_description.sequence_order]
--    disjunctive_chaum_pedersen_nonce = next(iter(nonce_sequence))
 +    selection_nonce = nonce_sequence.get(selection_description.sequence_order)
-+    disjunctive_chaum_pedersen_nonce = nonce_sequence.get(selection_description.sequence_order+1)
+     disjunctive_chaum_pedersen_nonce = next(iter(nonce_sequence))
  
      selection_representation = selection.to_int()
+@@ -174,7 +111,6 @@
+         return None
  
-@@ -249,8 +186,8 @@
+     # TODO: ISSUE #35: encrypt/decrypt: encrypt the extended_data field
+-
+     # Create the return object
+     encrypted_selection = make_ciphertext_ballot_selection(
+         object_id=selection.object_id,
+@@ -249,7 +185,7 @@
      # account for sequence id
      contest_description_hash = contest_description.crypto_hash()
      nonce_sequence = Nonces(contest_description_hash, nonce_seed)
 -    contest_nonce = nonce_sequence[contest_description.sequence_order]
--    chaum_pedersen_nonce = next(iter(nonce_sequence))
 +    contest_nonce = nonce_sequence.get(contest_description.sequence_order)
-+    chaum_pedersen_nonce = nonce_sequence.get(contest_description.sequence_order+1)
+     chaum_pedersen_nonce = next(iter(nonce_sequence))
  
      encrypted_selections  = list()
+@@ -418,7 +354,6 @@
+     nonce_seed = CiphertextBallot.nonce_seed(
+         election_metadata.description_hash, ballot.object_id, random_master_nonce,
+     )
+-
+     encrypted_contests  = list()
  
+     # only iterate on contests for this specific ballot style
 diff -ruwN orig/electionguard/group.py build/electionguard/group.py
---- orig/electionguard/group.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/group.py	2020-10-28 12:42:55.000000000 +0100
+--- orig/electionguard/group.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/group.py	2020-11-03 09:49:54.000000000 +0100
 @@ -2,41 +2,35 @@
  # in the sense that performance may be less than hand-optimized C code, and no guarantees are
  # made about timing or other side-channels.
@@ -1159,10 +1315,27 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
          accessing `elem`, whose representation might change.
          """
 -        h = format(self.elem, "02X")
-+        h = self.elem.toString(16)
++        h = self.elem.toString(16).upper()
          if len(h) % 2:
              h = "0" + h
          return h
+@@ -53,14 +47,14 @@
+         Validates that the element is actually within the bounds of [0,Q).
+         Returns true if all is good, false if something's wrong.
+         """
+-        return 0 <= self.elem < Q
++        return 0 <= self.elem and self.elem.lesser(Q)
+ 
+     def is_in_bounds_no_zero(self)  :
+         """
+         Validates that the element is actually within the bounds of [1,Q).
+         Returns true if all is good, false if something's wrong.
+         """
+-        return 0 < self.elem < Q
++        return 0 < self.elem and self.elem.lesser(Q)
+ 
+     # overload != (not equal to) operator
+     def __ne__(self, other )  :
 @@ -75,20 +69,25 @@
          ) and eq_elems(self, other)
  
@@ -1188,10 +1361,35 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
          accessing `elem`, whose representation might change.
          """
 -        h = format(self.elem, "02X")
-+        h = self.elem.toString(16)
++        h = self.elem.toString(16).upper()
          if len(h) % 2:
              h = "0" + h
          return h
+@@ -105,21 +104,21 @@
+         Validates that the element is actually within the bounds of [0,P).
+         Returns true if all is good, false if something's wrong.
+         """
+-        return 0 <= self.elem < P
++        return 0 <= self.elem and self.elem.lesser(P)
+ 
+     def is_in_bounds_no_zero(self)  :
+         """
+         Validates that the element is actually within the bounds of [1,P).
+         Returns true if all is good, false if something's wrong.
+         """
+-        return 0 < self.elem < P
++        return 0 < self.elem and self.elem.lesser(P)
+ 
+     def is_valid_residue(self)  :
+         """
+         Validates that this element is in Z^r_p.
+         Returns true if all is good, false if something's wrong.
+         """
+-        residue = pow_p(self, ElementModQ(mpz(Q))) == ONE_MOD_P
++        residue = pow_p(self, ElementModQ(Q)).__eq__(ONE_MOD_P)
+         return self.is_in_bounds() and residue
+ 
+     # overload != (not equal to) operator
 @@ -135,7 +134,10 @@
          ) and eq_elems(self, other)
  
@@ -1240,16 +1438,17 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
      else:
          return None
  
-@@ -187,7 +184,7 @@
+@@ -186,8 +183,7 @@
+     element (i.e., outside of [0,Q)). Useful for tests of it
      you're absolutely, positively, certain the input is in-bounds.
      """
- 
+-
 -    m = mpz(int(i))
 +    m = mpz(i)
      return ElementModQ(m)
  
  
-@@ -197,9 +194,9 @@
+@@ -197,9 +193,9 @@
      Returns `None` if the number is out of the allowed
      [0,P) range.
      """
@@ -1261,7 +1460,7 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
      else:
          return None
  
-@@ -211,24 +208,9 @@
+@@ -211,24 +207,9 @@
      element (i.e., outside of [0,P)). Useful for tests or if
      you're absolutely, positively, certain the input is in-bounds.
      """
@@ -1287,7 +1486,7 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
  def add_q(*elems )  :
      """
      Adds together one or more elements in Q, returns the sum mod Q.
-@@ -237,7 +219,7 @@
+@@ -237,7 +218,7 @@
      for e in elems:
          if isinstance(e, int):
              e = int_to_q_unchecked(e)
@@ -1296,16 +1495,20 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
  
      return ElementModQ(t)
  
-@@ -251,7 +233,7 @@
+@@ -251,7 +232,11 @@
      if isinstance(b, int):
          b = int_to_q_unchecked(b)
  
 -    return ElementModQ((a.elem - b.elem) % Q)
-+    return ElementModQ(a.elem.minus(b.elem).mod(Q))
++    result = a.elem.minus(b.elem)
++    if result < 0:
++        return ElementModQ(result.mod(Q).plus(Q)) 
++
++    return ElementModQ(result.mod(Q))
  
  
  def div_p(a , b )  :
-@@ -263,7 +245,7 @@
+@@ -263,7 +248,7 @@
      if isinstance(b, int):
          b = int_to_p_unchecked(b)
  
@@ -1314,7 +1517,7 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
      return mult_p(a, int_to_p_unchecked(inverse))
  
  
-@@ -276,7 +258,7 @@
+@@ -276,7 +261,7 @@
      if isinstance(b, int):
          b = int_to_p_unchecked(b)
  
@@ -1323,7 +1526,7 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
      return mult_q(a, int_to_q_unchecked(inverse))
  
  
-@@ -286,7 +268,7 @@
+@@ -286,7 +271,7 @@
      """
      if isinstance(a, int):
          a = int_to_q_unchecked(a)
@@ -1332,7 +1535,7 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
  
  
  def a_plus_bc_q(
-@@ -302,7 +284,7 @@
+@@ -302,7 +287,7 @@
      if isinstance(c, int):
          c = int_to_q_unchecked(c)
  
@@ -1341,7 +1544,7 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
  
  
  def mult_inv_p(e )  :
-@@ -315,7 +297,7 @@
+@@ -315,7 +300,7 @@
          e = int_to_p_unchecked(e)
  
      assert e.elem != 0, "No multiplicative inverse for zero"
@@ -1350,7 +1553,7 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
  
  
  def pow_p(b , e )  :
-@@ -331,7 +313,7 @@
+@@ -331,7 +316,7 @@
      if isinstance(e, int):
          e = int_to_p_unchecked(e)
  
@@ -1359,7 +1562,7 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
  
  
  def pow_q(b , e )  :
-@@ -347,7 +329,7 @@
+@@ -347,7 +332,7 @@
      if isinstance(e, int):
          e = int_to_q_unchecked(e)
  
@@ -1368,7 +1571,7 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
  
  
  def mult_p(*elems )  :
-@@ -360,7 +342,7 @@
+@@ -360,7 +345,7 @@
      for x in elems:
          if isinstance(x, int):
              x = int_to_p_unchecked(x)
@@ -1377,7 +1580,7 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
      return ElementModP(product)
  
  
-@@ -374,7 +356,7 @@
+@@ -374,7 +359,7 @@
      for x in elems:
          if isinstance(x, int):
              x = int_to_p_unchecked(x)
@@ -1386,7 +1589,7 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
      return ElementModQ(product)
  
  
-@@ -393,7 +375,7 @@
+@@ -393,7 +378,7 @@
  
      :return: Random value between 0 and Q
      """
@@ -1395,7 +1598,7 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
  
  
  def rand_range_q(start )  :
-@@ -408,7 +390,7 @@
+@@ -408,7 +393,7 @@
  
      random = 0
      while random < start:
@@ -1404,36 +1607,34 @@ diff -ruwN orig/electionguard/group.py build/electionguard/group.py
      return int_to_q_unchecked(random)
  
  
-@@ -416,4 +398,4 @@
+@@ -416,4 +401,4 @@
      """
      Returns whether the two elements hold the same value.
      """
 -    return a.elem == b.elem
 +    return a.elem.eq(b.elem)
 diff -ruwN orig/electionguard/hash.py build/electionguard/hash.py
---- orig/electionguard/hash.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/hash.py	2020-10-28 11:39:59.000000000 +0100
-@@ -1,12 +1,7 @@
+--- orig/electionguard/hash.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/hash.py	2020-10-30 09:48:02.000000000 +0100
+@@ -1,11 +1,3 @@
 -from abc import abstractmethod
 -from hashlib import sha256
-+
- from typing import (
+-from typing import (
 -    Union,
 -    Protocol,
 -    runtime_checkable,
 -    Sequence,
-+    Sequence
- )
--
+-)
+ 
  from electionguard.group import (
      ElementModPOrQ,
-     ElementModQ,
-@@ -14,15 +9,16 @@
+@@ -14,15 +6,17 @@
      int_to_q_unchecked,
      ElementModP,
  )
 +import BigInteger as bigInt
 +from Hash import sha256
++from Array import isArray
  
 +mpz = bigInt
  
@@ -1448,7 +1649,7 @@ diff -ruwN orig/electionguard/hash.py build/electionguard/hash.py
      def crypto_hash(self)  :
          """
          Generates a hash given the fields on the implementing instance.
-@@ -30,13 +26,11 @@
+@@ -30,13 +24,11 @@
          ...
  
  
@@ -1463,7 +1664,7 @@ diff -ruwN orig/electionguard/hash.py build/electionguard/hash.py
      def crypto_hash_with(self, seed_hash )  :
          """
          Generates a hash with a given seed that can be checked later against the seed and class metadata.
-@@ -44,16 +38,7 @@
+@@ -44,16 +36,7 @@
          ...
  
  
@@ -1481,7 +1682,7 @@ diff -ruwN orig/electionguard/hash.py build/electionguard/hash.py
  
  def hash_elems(*a )  :
      """
-@@ -66,7 +51,7 @@
+@@ -66,12 +49,11 @@
      :return: A cryptographic hash of these elements, concatenated.
      """
      h = sha256()
@@ -1490,21 +1691,35 @@ diff -ruwN orig/electionguard/hash.py build/electionguard/hash.py
      for x in a:
          # We could just use str(x) for everything, but then we'd have a resulting string
          # that's a bit Python-specific, and we'd rather make it easier for other languages
-@@ -91,8 +76,9 @@
+         # to exactly match this hash function.
+-
+         if not x:
+             # This case captures empty lists and None, nicely guaranteeing that we don't
+             # need to do a recursive call if the list is empty. So we need a string to
+@@ -86,13 +68,16 @@
+         elif isinstance(x, str):
+             # strings are iterable, so it's important to handle them before the following check
+             hash_me = x
+-        elif isinstance(x, Sequence):
++        elif isArray(x):
++            if x.length == 0:
++                hash_me = "null"
++            else:
+             # The simplest way to deal with lists, tuples, and such are to crunch them recursively.
              hash_me = hash_elems(*x).to_hex()
          else:
              hash_me = str(x)
 -        h.update((hash_me + "|").encode("utf-8"))
+-
 +        h.update((hash_me + "|"))
- 
      # We don't need the checked version of int_to_q, because the
      # modulo operation here guarantees that we're in bounds.
 -    return int_to_q_unchecked(int.from_bytes(h.digest(), byteorder="big") % Q_MINUS_ONE)
 +    return int_to_q_unchecked(mpz(h.digest(), 16).mod(Q_MINUS_ONE))
 +
 diff -ruwN orig/electionguard/logs.py build/electionguard/logs.py
---- orig/electionguard/logs.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/logs.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/logs.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/logs.py	2020-10-29 11:24:41.000000000 +0100
 @@ -1,14 +1,11 @@
 -import inspect
 -import logging
@@ -1662,8 +1877,8 @@ diff -ruwN orig/electionguard/logs.py build/electionguard/logs.py
 -    LOG.critical(msg, *args, **kwargs)
 +    LOG.critical(msg)
 diff -ruwN orig/electionguard/nonces.py build/electionguard/nonces.py
---- orig/electionguard/nonces.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/nonces.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/nonces.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/nonces.py	2020-10-28 16:03:13.000000000 +0100
 @@ -1,10 +1,8 @@
 -from typing import Union, Sequence, List, overload
 -
@@ -1676,10 +1891,10 @@ diff -ruwN orig/electionguard/nonces.py build/electionguard/nonces.py
      """
      Creates a sequence of random elements in [0,Q), seeded from an initial element in [0,Q).
      If you start with the same seed, you'll get exactly the same sequence. Optional string
-@@ -22,27 +20,13 @@
+@@ -21,27 +19,14 @@
+             self.__seed  = hash_elems(seed, *headers)
          else:
              self.__seed = seed
- 
 -    # https://github.com/python/mypy/issues/4108
 -    @overload
 -    def __getitem__(self, index )  :
@@ -1688,7 +1903,7 @@ diff -ruwN orig/electionguard/nonces.py build/electionguard/nonces.py
 -    @overload
 -    def __getitem__(self, index )  :
 -        pass
--
+ 
 -    def __getitem__(
 +    def get(
          self, index  
@@ -1709,8 +1924,8 @@ diff -ruwN orig/electionguard/nonces.py build/electionguard/nonces.py
      def __len__(self)  :
          raise TypeError("Nonces does not have finite length")
 diff -ruwN orig/electionguard/proof.py build/electionguard/proof.py
---- orig/electionguard/proof.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/proof.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/proof.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/proof.py	2020-10-28 15:25:36.000000000 +0100
 @@ -16,10 +16,10 @@
  class Proof(Serializable):
      """Base class for proofs with name and usage case"""
@@ -1725,8 +1940,8 @@ diff -ruwN orig/electionguard/proof.py build/electionguard/proof.py
 +            self, "_name", space_between_capitals(self.__class__.__name__)
          )
 diff -ruwN orig/electionguard/serializable.py build/electionguard/serializable.py
---- orig/electionguard/serializable.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/serializable.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/serializable.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/serializable.py	2020-10-29 12:48:10.000000000 +0100
 @@ -1,29 +1,14 @@
  from dataclasses import dataclass
  from datetime import datetime
@@ -1870,7 +2085,7 @@ diff -ruwN orig/electionguard/serializable.py build/electionguard/serializable.p
  
  
  def read_json(data , class_out )  :
-@@ -172,8 +80,7 @@
+@@ -172,79 +80,14 @@
      :param class_out: Object type
      :return: Deserialized object
      """
@@ -1879,8 +2094,11 @@ diff -ruwN orig/electionguard/serializable.py build/electionguard/serializable.p
 +    return parse_json(data, class_out)
  
  
- def read_json_object(data , class_out )  :
-@@ -183,68 +90,4 @@
+-def read_json_object(data , class_out )  :
++def read_json_object(data , class_out, endian = 'big')  :
+     """
+     Deserialize json file to object
+     :param data: Json file data
      :param class_out: Object type
      :return: Deserialized object
      """
@@ -1949,26 +2167,26 @@ diff -ruwN orig/electionguard/serializable.py build/electionguard/serializable.p
 -    """
 -    tz_corrected = re.sub("Z$", "+00:00", value)
 -    return datetime.fromisoformat(tz_corrected)
-+    return parse_json_object(data, class_out)
++    return parse_json_object(data, class_out, endian)
 diff -ruwN orig/electionguard/singleton.py build/electionguard/singleton.py
---- orig/electionguard/singleton.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/singleton.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/singleton.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/singleton.py	2020-10-28 15:25:36.000000000 +0100
 @@ -1,4 +1,3 @@
 -from typing import Any
  
  
  class Singleton:
 diff -ruwN orig/electionguard/tracker.py build/electionguard/tracker.py
---- orig/electionguard/tracker.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/tracker.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/tracker.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/tracker.py	2020-10-28 15:25:36.000000000 +0100
 @@ -1,4 +1,3 @@
 -from typing import List, Optional
  from electionguard.hash import hash_elems
  from electionguard.group import ElementModQ
  from electionguard.words import get_word
 diff -ruwN orig/electionguard/utils.py build/electionguard/utils.py
---- orig/electionguard/utils.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/utils.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/utils.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/utils.py	2020-10-28 15:25:36.000000000 +0100
 @@ -1,10 +1,5 @@
  from datetime import datetime, timezone
 -from os import mkdir, path
@@ -1993,17 +2211,77 @@ diff -ruwN orig/electionguard/utils.py build/electionguard/utils.py
      return int(ticks)
  
 diff -ruwN orig/electionguard/words.py build/electionguard/words.py
---- orig/electionguard/words.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/electionguard/words.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/electionguard/words.py	2020-11-03 10:10:47.000000000 +0100
++++ build/electionguard/words.py	2020-10-28 15:25:36.000000000 +0100
 @@ -1,5 +1,3 @@
 -from typing import Optional
 -
  MIN_INDEX = 0
  MAX_INDEX = 4095
  
+diff -ruwN orig/jsons.js build/jsons.js
+--- orig/jsons.js	2020-11-03 10:10:47.000000000 +0100
++++ build/jsons.js	2020-10-30 10:27:36.000000000 +0100
+@@ -10,7 +10,7 @@
+   return str.replace(/-/g, '+').replace(/_/g, '/');
+ }
+ 
+-function b64ToBn(b64) {
++function b64ToBn(b64, endian = 'big') {
+   var bin = atob(b64);
+   var hex = [];
+ 
+@@ -19,9 +19,11 @@
+     if (h.length % 2) { h = '0' + h; }
+     hex.push(h);
+   });
+-
++  if (endian == 'big') {
+   return BigInt('0x' + hex.join(''));
+ }
++  return BigInt('0x' + hex.reverse().join(''));
++}
+ 
+ 
+ export var dump_json = function(instance, strip_privates = true) {
+@@ -38,11 +40,15 @@
+   return parse_json_object(JSON.parse(data), class_out);
+ }
+ 
+-export var parse_json_object = function(data, class_out) {
++export var parse_json_object = function(data, class_out, endian = 'big') {
+   if (class_out === 'Optional')
+       return data || null;
+ 
+   if (Array.isArray(class_out)) {
++    if (!data) {
++      return [];
++    }
++    
+     switch(class_out[0].__name__) {
+       case 'str':
+       case 'int':
+@@ -50,7 +56,7 @@
+         return data;
+       default:
+         return data.map(function(currentValue) {
+-          return parse_json_object(currentValue, class_out[0]);
++          return parse_json_object(currentValue, class_out[0], endian);
+         });
+     }
+   }
+@@ -61,7 +67,7 @@
+ 
+       case 'ElementModP':
+       case 'ElementModQ':
+-        return new class_out(new bigInt(b64ToBn(urlBase64ToBase64(data))));
++        return new class_out(new bigInt(b64ToBn(urlBase64ToBase64(data), endian)));
+ 
+       case 'str':
+       case 'int':
 diff -ruwN orig/tests/test_voter.py build/tests/test_voter.py
---- orig/tests/test_voter.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/tests/test_voter.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/tests/test_voter.py	2020-11-03 10:10:48.000000000 +0100
++++ build/tests/test_voter.py	2020-10-28 15:25:36.000000000 +0100
 @@ -1,9 +1,8 @@
 -import unittest
  from tests.utils import create_election_test_message, joint_election_key_test_message
@@ -2032,8 +2310,8 @@ diff -ruwN orig/tests/test_voter.py build/tests/test_voter.py
 -if __name__ == '__main__':
 -    unittest.main()
 diff -ruwN orig/tests/utils.py build/tests/utils.py
---- orig/tests/utils.py	2020-10-28 12:12:03.000000000 +0100
-+++ build/tests/utils.py	2020-10-28 10:01:57.000000000 +0100
+--- orig/tests/utils.py	2020-11-03 10:10:48.000000000 +0100
++++ build/tests/utils.py	2020-10-30 09:15:04.000000000 +0100
 @@ -10,7 +10,7 @@
              {'name': 'clara', 'public_key': '...'}
          ],
@@ -2043,25 +2321,33 @@ diff -ruwN orig/tests/utils.py build/tests/utils.py
              'start_date': '2021-03-01T08:00:00-05:00',
              'end_date': '2021-03-01T20:00:00-05:00',
              'candidates': [
-@@ -31,7 +31,7 @@
+@@ -30,8 +30,10 @@
+                     '@type': 'ReferendumContest',
                      'object_id': 'question1',
                      'sequence_order': 0,
-                     'vote_variation': 'one_of_m',
+-                    'vote_variation': 'one_of_m',
 -                    'name': 'Question 1',
++                    'vote_variation': {
++                        '_name': 'one_of_m',
++                    },
 +                    '_name': 'Question 1',
                      'number_elected': 1,
                      'minimum_elected': 1,
                      'ballot_title': {'text': [{'value': 'Do you agree?', 'language': 'en'}]},
-@@ -46,7 +46,7 @@
+@@ -45,8 +47,10 @@
+                     '@type': 'CandidateContest',
                      'object_id': 'question2',
                      'sequence_order': 1,
-                     'vote_variation': 'n_of_m',
+-                    'vote_variation': 'n_of_m',
 -                    'name': 'Question 2',
++                    'vote_variation': {
++                        '_name': 'n_of_m',
++                    },
 +                    '_name': 'Question 2',
                      'number_elected': 2,
                      'minimum_elected': 0,
                      'ballot_title': {'text': [{'value': 'Choose the projects that you like', 'language': 'en'}]},
-@@ -77,7 +77,7 @@
+@@ -77,7 +81,7 @@
              'election_public_key_proof': {
                  'challenge': '7ER1o3ZlShoCD8Okg5Q6uaUAJUpL1l7SdD4pg6CkAw8=',
                  'commitment': 'pl8zhjfiBLMCm/IgqapjuvmiU0d1EmfOANkf+ld3+R+EqWLZQ0K4l3Ae3Dv3ipP2dgKqNv/wGe61ZoRvhFGkQJnxXo/nFH3OR9bwqZLHpv6ZYeSX3ajD/f+M7nFUCbxDyZvlZYcPLcr2LSgFPXyKDr9tqpazpkQBo44ztZDIe1llv+aaxoiJP/A36IO0bVGKDG2BEU99+qUPMk8rxzaahI3u7yhI8MOC2FJUWTWwTZgnWsV2DnduGaW2cipCG1mbs3OfqHTodl10rOeLngw9CyybfvZdp0YIv1WLGO6S5jadJBYhptUCpamLW0C5pVpCG8uvTaR28kKS9h0NqEu6qa8g5Ow5bKrfxV2vb9SH4Ut1+2+9HqPyjGN16jKMIT79ZCu1iEEN2+RUw9K0rdRaqhKcOY9imLeHk8L5D0GJpR5MYgluFCmDl/+YDZbzE/m165OPiirqlSpY9gn9jCflDuXx9gR/kqsw28z1ImYo7eBDRPG2tQGgExibhycK4SLxPBL3nvYwtlrvd0EtP7eyA6Wb1RotJ92snSH5J5SleNBNCFEWm6cnlGGJ5el/2/kG/jcDVXLz4V02s6+FTbWXTF6s9mOg9Jp65av/T2umlfWvgT/r72AGyOn4hQtI9aGdyv7xPxyU7iiZa2h7BUpEQ3R5F2CO8NmBpdS0m5VEfrA=',  # noqa: E501
@@ -2070,7 +2356,7 @@ diff -ruwN orig/tests/utils.py build/tests/utils.py
                  'public_key': 'UxmYOgII7XfkqtmIhkm2I3W5g83recLynlu+z6qK9/iSyB1hW+H7j7KpKnd+pLAOCnxrKA7Kglxk4x5jQdXfYRhiTkL9TzIhejVoXpFFEqH8I1+8mPCYMPY1GxBhZodbAl3CRSIRqS7IMQfFZ6gtZFjrij5P70SuXYyI+K2igVcQuG1BK8CKFXpzDxiKhbVltIjNk4un8K48lTkNqH+nyJ+GQiBUi+x2/gGxgF6naQO9Z/ZAgTcECf9J7LnPxY/0iFkAyJsQiyDpktPCVfy5aAfUYwbDxatIIoE7ujKXyxrbEHPu+VtX3GvLRb53kPp8Wuh3b8eDSagwmh4Fa/yHpcfq1CJSGT4C4K55VbtQ1PcMTQyGJEtgBjpU/3XGyLK1TarnmFlZonKRiuYhHMLKmj4E1F5jaJ12/AwS+jXjTASZwMHgVdflkMCH/rceutcLTKtISNtZdGmP9JcnQ1uOCr1EQe/2sTlz1M8YzvupoPtBUE9ZtgvxGzPKx+tldJQv1cqVsAYTmEL3McUFeK3YLa5819kAOdZ/1tGy3pk3mIRdbiD1GFyiW3MEOwEAKVikIxninC0TwIw0ZiKh5C6YP3mOTN2C8zmWle1uPihO7XLK0f4TKC0pyCMXklkyZa05ZmjWgctJ17RWjLE1boNVTFwFOmy3ASErzDGbJtu9g8A=',  # noqa: E501
                  'response': 'puH3SmTJnSn4JL3uDM5exiB0mDa67vibiu3qkA8IbCM=',
                  'usage': 'SecretValue'
-@@ -90,7 +90,7 @@
+@@ -90,7 +94,7 @@
              'election_public_key_proof': {
                  'challenge': 'jTFR44h84a0/XwiKNwdtSDaTb3EYJjOuePX6uaYn2Ds=',
                  'commitment': 'hQXsT3tF9zhu5LcK4IFr8sTZmMXbkUMRXqFzlTUdV8ekcB/0ZwoC6zWcdia5BpSv4og2eIUR1kuGS+rTSa4LkaUd4Zl3pZ2M+PYR4J/chnBkVl70fRQBbCBiOi1/QtVniY+hOFR/x/r/sUYoTTVql2uy/mAsk12DXz5jwzFOsLEXCuagJxk9cCmzU8VTFLkIespup0A3HXFkdIihhUoXI24itIPmknn8umeJcgdSZkAc0uUzn/PFeg2Oul7any6DoLVA5nqpisp04w0NVSCxGEdNpS5fNKxpjm1HJr3xzqyySm21o2W8gokThV1y+NZsxGyRekjeDN5e5LeK2gTkLXyhtpFbEH6nGYYxHGYZrpt1ynamK41j8xp/FkibkGqzdBbkVuaLL+FcGy0PO6fGH2GyJEgPdOrAk3Jby1zaAz9UixLTwX31vCXeYVVStCwuHjT6uWKLDFNjXAUDRepg+TvejGUWKAuVF7QvH7hXoy2yuQT7abf7Z07TE0ZBTte+7UMUp/4rd4V6pWv/TiryLpkV3/8gUgNghfX5kP4jVxmXB0SHwdyeJ8rOjRt6KNgkK+SBds8GvB4ndj3QI7V9MXSH127yfNgwGcI74tekWIWjV/Z9mZZroZgbWbirINHV/2R4jvNihoEJOUQyqR1GC+x39Ew8jfjb1WgtVGJcZ4U=',  # noqa: E501
@@ -2079,7 +2365,7 @@ diff -ruwN orig/tests/utils.py build/tests/utils.py
                  'public_key': '7+o8hAuyqbgCBixFFyIxUim4sGgjsVhQVP0o10ohgBN5++f2ohuBvSbBb9VzKx4vmRzd7sfCxwpAeo+z/QQVmDHWLrcp17y/kYbipB3cE3ewsneojyh+qEqY5H9/QiRZkC2X3XVqPVxJv5aVS3Um4vFsfCgS6uWc6HxayWu0TOgQu5FNH4hQxQH7QI68u4uthuvyUfH0t7rqXgOoBbXpm3vPrJBnLvCaxL3FBUvQH27nW5prQoRFCjzUZgEJJtUbykIPWCI/VMT/Ui8jwx3EA8bsVwUti3Mdptlv9MilOlPKo7ChaNg/vzVqsmX2xKXGXhBijgG1iey+5FnIZPQBs/fCkHc9h13pVaEJemJDhZIhiYQ2KxDmf2bWk/ZR5LKX4kFpyY+MI3KSkK2HGrvFiLej2Wxc3jWUK3LmVBCxxB1JrAX94k5fOalVGA74cNte1dp644fR+7h/7K4huDfoVbqh+arkMfg1VDEnPCMjPuox+mwR0DfDvL1niOFNwSNuSdeFqRMdj0Fcx5vG4KXCZTDlPUQIcu9VwdQnXJWqf1izh7Ol2Oi4//Y+3PX8BzMUSyt3L1x2h8kC7sHvIVO+bA9zEjN105X0RJcLkP6WM/27MyrlcfSbWAD2LOBoXySTxiv0wBuDxowo/X2nW7nTcHqu2gaabeZQGMf8/F9VI/o=',  # noqa: E501
                  'response': 'AQy+BIv++6QaVlDQNIpd45ZIarh/0weEaGTs8a4yJE8=',
                  'usage': 'SecretValue'
-@@ -103,7 +103,7 @@
+@@ -103,7 +107,7 @@
              'election_public_key_proof': {
                  'challenge': 'MK6CmlcHRCeI2Fq5GZAsonlUiD6VPcZHpXzM8gFWSoU=',
                  'commitment': 'XRoO9PiizLZ2q7UiA2887LSbAuIE/NRLpNibEh6G3BZSJfkTpIGhmOm/1Qiw2wbWqM8ndlPh64GV+D5wjzmUEchva6mwtvVNfDCsP+hm+ELAKDUH9O+tiIbpDn+uzb2Y/O4En+eh6XtFyAjh6a6kDKkuEtxVQ6KLmbDuNjc5c0Bz6vM+97uFqLoIV9nDhDAypCXOsBsrRQhkBcQ+1n1U35astAUpSM3gdRNzQdHvjO1Gh+G9eprr3uWYaMMv8m/sp4xTrLB6vno/Tbcwa1vdkzo7EeIu+xQQYuttqPgvFVhxErEaw7CHMgqVN5LBWcmI5nulvEEWYtS6m6eZ1oqB7BnLTOADIlR1f1UIL2xiCOwKqWGXhD2j4Y/XTujzE0ZGxTp8/jXLmLiH3QgW31q61KPkvPHgCLwZ5Ty9vGmRwe18hAZwPqpYaZAmcMSZX7F43pHC2UNJTp5Kr2YeHxaEi6N3cKSg1zFsL9CWBD7dGbfIAMxUsE/yKH805x/+HWm5tGf2sdxaeOvBhL29gC2g1WJdw2hNiWKDzAjjk6KlLQEgA9UgT3/93WcN5bTTrO8ETYIMAg7U8Pd1Rp6GR7wgKCox5aDZsXkOitvNMOHXWosMWl602oRGXMYN6iFUyWPdkMxpaYx2kFXx0Kc9UDH2D3stlvI0fSNykEdxBpyEdVs=',  # noqa: E501

--- a/sources/modules/Array.js
+++ b/sources/modules/Array.js
@@ -1,0 +1,3 @@
+export const isArray = (data) => {
+    return Array.isArray(data)
+}

--- a/sources/modules/Nonces.js
+++ b/sources/modules/Nonces.js
@@ -1,0 +1,38 @@
+import { hash_elems } from "./electionguard.hash.js";
+
+class NoncesIterator {
+    constructor(seed, ...headers) {
+        if (headers.length > 0) {
+            this.seed = hash_elems(seed, ...headers);
+        } else {
+            this.seed = seed;
+        }
+        this.index = 0;
+    }
+
+    next() {
+        return {
+            value: this.py_get(this.index++),
+            done: false
+        };
+    }
+
+    py_get(index) {
+        return this.getWithHeaders(index);
+    }
+
+    getWithHeaders(item, ...headers) {
+        if(item < 0) {
+            throw new Error("Nonces do not support negative indices.");
+        }
+        return hash_elems(this.seed, item, ...headers);
+    }
+
+    [Symbol.iterator]() {
+        return this;
+    }
+}
+
+export const Nonces = (seed, ...headers) => {
+    return new NoncesIterator(seed, ...headers);
+}


### PR DESCRIPTION
## ✍️ Description

In this PR I focused on having the same result in both the JS and the Python version. I finally succeed performing a few changes to the transpiled code:

- Added new javascript module `Array` to replace `isinstance(x, Sequence)` with `isArray(x)`.
- Added new javascript module `Nonces` to replace the python version. The javascript version is an `Iterator` so the python code that interacts with the iterator is transpiled successfully.
- I changed the `jsons` javascript module to be able to parse numbers in `big` or `little` endians. I also made a small fix related to empty arrays.
- The `==` operator doesn't work with our `Biginteger.js` library so we need to use the function `__eq__`.
- Same for the `<` operator. We need to use the library function version called `lesser`
- Some `_types` were missing so the JS objects were wrong.
- I changed the `tests/utils` python module to match the correct shape of the objects being parsed (i.e. `vote_variation` is an object with a `_name` property).

If you clean the project and try to apply the patches there are a couple of issues that need to be fixed manually at the moment:
- `build/electionguard/dlog.py` has a bad indentation in the `__discrete_log_internal` method
- `build/electionguard/hash.py` has a bad indentation in the `hash_elems` method.